### PR TITLE
fix(docker): not restarting on crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "type": "module",
     "scripts": {
-        "dev": "nodemon --env-file=.env src/index.js",
+        "dev": "nodemon --env-file=.env --exitcrash src/index.js",
         "db": "node db/database.js"
     },
     "keywords": [],


### PR DESCRIPTION
### What's happening?
Although Docker daemon is instructed [to always restart](https://github.com/statuscompliance/infraestructure/blob/main/docker-compose.yml#L29) in case the backend crashes, this doesn't happen in practice and the container is left in a hung state. The reason it's that the backend runs through nodemon, which keeps running after the backend crash. Hence, the Docker daemon always detects the entrypoint process as running.

### Proposed solution

Right now, if the backend crashes, nodemon will detect it but do nothing, since all nodemon does is to watch for file changes and restart the server **only in case a file changes**. By adding this argument, nodemon will crash alongside the process so Docker daemon restarts the entire container.

### Additional context

- *I'm opening this Pull Request in this branch because it's the one used in the ``setup.sh`` ran during the [Installation](https://status-docs.netlify.app/docs/Getting-started/installation) section of the docs, so I assume it's the most up to date. Please let me know if I should target other branch instead.*
- The backend should gracefully handle malformed authentication requests or JWT without crashing whatsoever (right now, running a simple GET /api/v1/user/auth without no credentials will crash the application. Improving all of this is of course out of the scope of this PR, but I'm leaving it here for future reference, so you're aware of this issue. If I have spare time later this week after finishing all my tasks I might be able to create a PR fixing this.