### PR TITLE
fix: Check token existence

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -136,14 +136,17 @@ export async function getUsers(req, res) {
 }
 
 export async function getAuthority(req, res) {
-    if (!req.headers["authorization"] || !req.headers["Authorization"]) {
-        return res.status(401).json({ message: "No token provided" });
-    } else {
-        const accessToken =
-            req.headers["authorization"].split(" ")[1] ||
-            req.headers["Authorization"].split(" ")[1];
-        const decoded = jwt.verify(accessToken, process.env.JWT_SECRET);
-        const authority = decoded.authority;
-        res.status(200).json({ authority: authority });
+    const auth = req.headers?.["authorization"] ?? req.headers?.["Authorization"];
+    const accessToken = auth?.split(" ")?.[1];
+    
+    try {
+        if (!auth || !accessToken) {
+            throw new Error();
+        } else {
+            const { authority } = jwt.verify(accessToken, process.env.JWT_SECRET);
+            res.status(200).json({ authority });
+        }
+    } catch {
+        return res.status(401).json({ message: "No token provided or it's malformed" });
     }
 }

--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -136,10 +136,14 @@ export async function getUsers(req, res) {
 }
 
 export async function getAuthority(req, res) {
-    const accessToken =
-        req.headers["authorization"].split(" ")[1] ||
-        req.headers["Authorization"].split(" ")[1];
-    const decoded = jwt.verify(accessToken, process.env.JWT_SECRET);
-    const authority = decoded.authority;
-    res.status(200).json({ authority: authority });
+    if (!req.headers["authorization"] || !req.headers["Authorization"]) {
+        return res.status(401).json({ message: "No token provided" });
+    } else {
+        const accessToken =
+            req.headers["authorization"].split(" ")[1] ||
+            req.headers["Authorization"].split(" ")[1];
+        const decoded = jwt.verify(accessToken, process.env.JWT_SECRET);
+        const authority = decoded.authority;
+        res.status(200).json({ authority: authority });
+    }
 }


### PR DESCRIPTION
### What's happening?
This PR solve the issue detailed in the PR #22:
> The backend should gracefully handle malformed authentication requests or JWT without crashing whatsoever (right now, running a simple GET /api/v1/user/auth without no credentials will crash the application. Improving all of this is of course out of the scope of this PR, but I'm leaving it here for future reference, so you're aware of this issue. 

### Solution
Now, the system throws a 401 "No token provided" error if the user is not authorised.