### PR TITLE
Fix: SQL Syntax Error in Sequelize Table Creation

### DIFF
--- a/src/models/control.model.js
+++ b/src/models/control.model.js
@@ -1,33 +1,37 @@
-import { DataTypes } from 'sequelize';
-import sequelize from '../../db/database.js';
+import { DataTypes } from "sequelize";
+import sequelize from "../../db/database.js";
 
-const Control = sequelize.define('Control', {
-    name: {
-        type: DataTypes.STRING(100),
-        allowNull: false
+const Control = sequelize.define(
+    "Control",
+    {
+        name: {
+            type: DataTypes.STRING(100),
+            allowNull: false,
+        },
+        description: {
+            type: DataTypes.TEXT,
+            allowNull: false,
+        },
+        period: {
+            type: DataTypes.ENUM("DAILY", "MONTHLY", "ANNUALLY"),
+            allowNull: false,
+        },
+        startDate: {
+            type: DataTypes.DATE,
+        },
+        endDate: {
+            type: DataTypes.DATE,
+        },
+        mashup_id: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+        },
     },
-    description: {
-        type: DataTypes.TEXT,
-        allowNull: false
-    },
-    period: {
-        type: DataTypes.ENUM('DAILY', 'MONTHLY', 'ANNUALLY'),
-        allowNull: false
-    },
-    startDate: {
-        type: DataTypes.DATE
-    },
-    endDate: {
-        type: DataTypes.DATE
-    },
-    mashup_id: {
-        type: DataTypes.NUMBER,
-        allowNull: false
+    {
+        tableName: "control",
+        timestamps: false,
     }
-}, {
-    tableName: 'control',
-    timestamps: false
-});
+);
 
 export default Control;
 

--- a/src/models/input_control.model.js
+++ b/src/models/input_control.model.js
@@ -1,20 +1,24 @@
-import { DataTypes } from 'sequelize';
-import sequelize from '../../db/database.js';
+import { DataTypes } from "sequelize";
+import sequelize from "../../db/database.js";
 
-const InputControl = sequelize.define('InputControl', {
-    value: {
-      type: DataTypes.STRING(255),
-      allowNull: false
+const InputControl = sequelize.define(
+    "InputControl",
+    {
+        value: {
+            type: DataTypes.STRING(255),
+            allowNull: false,
+        },
+        input_id: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+        },
     },
-    input_id: {
-      type: DataTypes.NUMBER,
-      allowNull: false
+    {
+        tableName: "input_control",
+        timestamps: false,
     }
-}, {
-  tableName: 'input_control',
-  timestamps: false
-});
-  
+);
+
 export default InputControl;
 
 /**


### PR DESCRIPTION
### **Description:**

**Problem:**
There was an SQL syntax error when attempting to create the `control` table in MySQL using Sequelize. The error occurred because the `NUMBER` data type was used in the table definition, which is not a valid data type in MySQL. The error message was: 

```
You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'NUMBER NOT NULL, `catalog_id` INTEGER, PRIMARY KEY (`id`), FOREIGN KEY (`catalog' at line 1
```

**Solution:**
This PR fixes the SQL syntax error by changing the `mashup_id` column's data type from `NUMBER` to `INTEGER`, which is a valid type in MySQL. The necessary changes were made in the Sequelize model to ensure compatibility with the MySQL dialect.

### **Changes Made:**
- Updated the Sequelize model definition for the `control` table to replace `NUMBER` with `INTEGER` for the `mashup_id` field.
- Modified any associated migration or schema files to reflect this change.

### **Testing:**
- Ran the migration scripts locally and verified that the table is now created successfully without any syntax errors.
- Conducted manual tests to ensure the application functions correctly after the change.
- Test the infrastructure installation script from scratch (having deleted all volumes).

### **Additional Notes:**
- This change does not impact any other parts of the application since it is limited to the table creation syntax in the MySQL database.


### Screenshot
<img width="1420" alt="Captura de pantalla 2024-08-31 a las 11 02 38" src="https://github.com/user-attachments/assets/e7e910b3-c1dc-4547-9e93-bd0ee3cec276">

