### PR TITLE
fix: Add node-red token to the sign-in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
+                "axios": "^1.7.7",
                 "bcrypt": "^5.1.1",
                 "cookie-parser": "^1.4.6",
                 "cors": "^2.8.5",
@@ -274,6 +275,16 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
+        "node_modules/axios": {
+            "version": "1.7.7",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+            "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -789,6 +800,25 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.15.9",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
             }
         },
         "node_modules/form-data": {
@@ -1791,6 +1821,11 @@
             "engines": {
                 "node": ">= 0.10"
             }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/pstree.remy": {
             "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
+        "axios": "^1.7.7",
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",


### PR DESCRIPTION
## Description

This PR introduces the following changes:

- **Validation for `nodeRedUrl`:**  
  A new function `isValidNodeRedUrl` has been added to ensure that the `nodeRedUrl` follows the correct format. The validation checks that the URL:
  - Starts with either `http://` or `https://`.
  - Contains a valid domain or host (e.g., `localhost`, `node-red-status`, etc.).
  - Optionally includes a port number (e.g., `:1880`).
  - Does **not** contain any additional path or endpoint beyond the root (e.g., `/api` or `/auth/token` would be invalid).

### Valid Examples:
- `https://localhost:1880`
- `http://localhost:1880`
- `http://node-red-status:1880`

### Invalid Examples:
- `http://node-red-status:1880/api`
- `http://localhost:1880/other-path`

This validation ensures that the `nodeRedUrl` meets the expected structure before proceeding with further logic.

## Changes

- Added `isValidNodeRedUrl` function to validate the format of `nodeRedUrl`.
- Updated the login flow to ensure the `nodeRedUrl` is valid before using it for token generation.

## How Has This Been Tested?
- **Manual testing**: Manually verified that valid URLs pass the check and invalid ones return appropriate error messages.
