### PR TITLE
test: added panel.structure-test

### DIFF
--- a/src/utils/panelStructures.js
+++ b/src/utils/panelStructures.js
@@ -13,12 +13,10 @@ function createPanelTemplate(type) {
     : undefined;
 
   if (!structure) {
-    throw new Error(`Tipo de panel no soportado: ${type}`);
+    throw new Error(`Panel type not supported: ${type}`);
   }
 
-  return {
-    ...structure,
-  };
+  return structuredClone(structure)
 }
 
 export default createPanelTemplate;

--- a/tests/unit/utils/panelStructures.test.js
+++ b/tests/unit/utils/panelStructures.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import createPanelTemplate from '../../../src/utils/panelStructures';
+import gaugeStructure from '../../../src/utils/gaugeStructure'; 
+
+describe('createPanelTemplate', () => {
+  it('should return the correct template for a supported type', () => {
+    const template = createPanelTemplate('gauge');
+    expect(template).toEqual(gaugeStructure);
+    // You might want to add more specific assertions based on the expected content of gaugeStructure
+    expect(template).toHaveProperty('type', 'gauge');
+    expect(template).toHaveProperty('options');
+  });
+
+  it('should throw an error when type is unsupported', () => {
+    const unsupportedType = 'unknown';
+    expect(() => createPanelTemplate(unsupportedType)).toThrowError(
+      `Panel type not supported: ${unsupportedType}`
+    );
+  });
+
+  it('should return a new object instance, not a reference to the original structure', () => {
+    const template1 = createPanelTemplate('gauge');
+    const template2 = createPanelTemplate('gauge');
+    expect(template1).not.toBe(gaugeStructure);
+    expect(template2).not.toBe(gaugeStructure);
+    expect(template1).not.toBe(template2);
+
+    // Verify that modifying the returned template doesn't affect the original structure
+    template1.newProperty = 'test';
+    expect(gaugeStructure).not.toHaveProperty('newProperty');
+  });
+
+  it('should deeply clone the structure, preventing shared nested references', () => {
+    const template = createPanelTemplate('gauge');
+    template.options.minVizWidth = 999;
+    expect(gaugeStructure.options.minVizWidth).not.toBe(999);
+  });
+});


### PR DESCRIPTION
feat(utils): deep clone panel structures using structuredClone + add unit tests

- Updated createPanelTemplate to use structuredClone for returning a deep copy 
  of the requested panel structure, avoiding shared nested references.

- Added a full test suite for createPanelTemplate:
  - Verifies correct structure is returned for supported types
  - Ensures error is thrown for unsupported types
  - Confirms a new object instance is returned (not a reference)
  - Tests deep cloning behavior to avoid shared mutation