### PR TITLE
feat(user): enhanced signOut to clear auth cookies

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -152,6 +152,16 @@ export async function signOut(req, res) {
         secure: true,
         sameSite: 'none',
       });
+      res.clearCookie('accessToken', {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none',
+      });
+      res.clearCookie('nodeRedToken', {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none',
+      });
       return res
         .status(404)
         .json({ message: 'No user found for provided refresh token' });
@@ -165,6 +175,16 @@ export async function signOut(req, res) {
     );
 
     res.clearCookie('refreshToken', {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'none',
+    });
+    res.clearCookie('accessToken', {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'none',
+    });
+    res.clearCookie('nodeRedToken', {
       httpOnly: true,
       secure: true,
       sameSite: 'none',

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -135,11 +135,15 @@ export default function () {
  * @swagger
  * /users/signOut:
  *   post:
- *     summary: Logs out a user by clearing the refresh token
+ *     summary: Logs out a user by clearing all cookies (accessToken, refreshToken, nodeRedToken)
  *     tags: [Auth]
  *     responses:
  *       204:
  *         description: User logged out successfully
+ *       404:
+ *         description: No user found for provided refresh token
+ *       400:
+ *         description: No refresh token provided
  *       500:
  *         description: Internal server error
  *         content:

--- a/tests/unit/controllers/user/user.controller.test.js
+++ b/tests/unit/controllers/user/user.controller.test.js
@@ -5,6 +5,15 @@ import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
 import * as nodeRedTokenModule from '../../../../src/utils/nodeRedToken.js';
 
+// Constants for reuse
+const MOCK_TOKEN = 'mockToken';
+const DEFAULT_USER = {
+  username: 'existingUser',
+  password: 'hashedPassword',
+  email: 'user@example.com',
+  authority: 'USER',
+};
+
 // Helper to create simple mock req/res objects
 function createRes() {
   return {
@@ -13,6 +22,43 @@ function createRes() {
     cookie: vi.fn(),
     clearCookie: vi.fn(),
   };
+}
+
+// Helper to setup common mocks for tests
+function setupUserMocks({
+  findOneValue = null,
+  findAllValue = [],
+  compareValue = false,
+  createValue = {},
+  updateValue = [1],
+} = {}) {
+  vi.spyOn(models.User, 'findOne').mockResolvedValue(findOneValue);
+  vi.spyOn(models.User, 'findAll').mockResolvedValue(findAllValue);
+  vi.spyOn(bcrypt, 'compare').mockResolvedValue(compareValue);
+  vi.spyOn(models.User, 'create').mockResolvedValue(createValue);
+  vi.spyOn(models.User, 'update').mockResolvedValue(updateValue);
+  return { findOne: models.User.findOne, findAll: models.User.findAll };
+}
+
+// Helper for common cookie clear expectations
+function expectCookiesCleared(res, includeNodeRed = true) {
+  expect(res.clearCookie).toHaveBeenCalledWith('refreshToken', {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'none',
+  });
+  expect(res.clearCookie).toHaveBeenCalledWith('accessToken', {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'none',
+  });
+  if (includeNodeRed) {
+    expect(res.clearCookie).toHaveBeenCalledWith('nodeRedToken', {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'none',
+    });
+  }
 }
 
 describe('User Controller Tests', () => {
@@ -24,12 +70,9 @@ describe('User Controller Tests', () => {
   // Test getUsers
   describe('getUsers', () => {
     it('should return a list of users with status 200', async () => {
-      // Mocking database response
       const mockUsers = [{ id: 1, name: 'John Doe' }];
-
       vi.spyOn(models.User, 'findAll').mockResolvedValue(mockUsers);
-
-      // Mocking request and response objects
+      
       const req = {};
       const res = createRes();
 
@@ -40,62 +83,50 @@ describe('User Controller Tests', () => {
     });
 
     it('should handle errors gracefully in getUsers', async () => {
-      vi.spyOn(models.User, 'findAll').mockRejectedValueOnce(
-        new Error('Database error')
-      );
-
+      vi.spyOn(models.User, 'findAll').mockRejectedValueOnce(new Error('Database error'));
+      
       const req = {};
       const res = createRes();
 
       await userController.getUsers(req, res);
 
       expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Internal server error',
-      });
+      expect(res.json).toHaveBeenCalledWith({ message: 'Internal server error' });
     });
   });
 
   // Test singUp
   describe('signUp', () => {
-    it('should return 400 if username exists', async () => {
-      const req = {
-        body: {
-          username: 'existingUser',
-          password: 'password123',
-          email: 'test@example.com',
-          authority: 'USER',
-        },
-      };
-      const res = createRes();
+    const signUpReqBody = {
+      username: 'existingUser',
+      password: 'password123',
+      email: 'test@example.com',
+      authority: 'USER',
+    };
 
-      // Set the mock for findAll
-      vi.spyOn(models.User, 'findOne').mockResolvedValue(null);
-      vi.spyOn(models.User, 'findAll').mockResolvedValue([
-        { username: 'existingUser' },
-      ]);
+    function createSignUpReq(overrides = {}) {
+      return { body: { ...signUpReqBody, ...overrides } };
+    }
+
+    it('should return 400 if username exists', async () => {
+      setupUserMocks({ 
+        findAllValue: [{ username: 'existingUser' }] 
+      });
+      
+      const req = createSignUpReq();
+      const res = createRes();
 
       await userController.signUp(req, res);
 
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Username already exists',
-      });
+      expect(res.json).toHaveBeenCalledWith({ message: 'Username already exists' });
     });
 
     it('should return 201 create user successfully in signUp', async () => {
-      const req = {
-        body: {
-          username: 'existingUser',
-          password: 'password123',
-          email: 'test@example.com',
-          authority: 'USER',
-        },
-      };
+      setupUserMocks();
+      
+      const req = createSignUpReq();
       const res = createRes();
-
-      vi.spyOn(models.User, 'findAll').mockResolvedValue([]);
-      vi.spyOn(models.User, 'create').mockResolvedValue({});
 
       await userController.signUp(req, res);
 
@@ -104,119 +135,82 @@ describe('User Controller Tests', () => {
         message: 'User existingUser created successfully with authority USER',
       });
     });
+
     it('should return 400 if username exists (case insensitive)', async () => {
-      const req = {
-        body: {
-          username: 'ExistingUser', // uppercase
-          password: 'password123',
-          email: 'test@example.com',
-          authority: 'USER',
-        },
-      };
+      setupUserMocks({ 
+        findAllValue: [{ username: 'existinguser' }]
+      });
+      
+      const req = createSignUpReq({ username: 'ExistingUser' });
       const res = createRes();
-
-      // Set the mock for findAll with case-insensitive search
-      vi.spyOn(models.User, 'findAll').mockResolvedValue([
-        { username: 'existinguser' }, // lowercase
-      ]);
 
       await userController.signUp(req, res);
 
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Username already exists',
-      });
+      expect(res.json).toHaveBeenCalledWith({ message: 'Username already exists' });
     });
-    it('should return 400 if email already exists', async () => {
-      const req = {
-        body: {
-          username: 'newUser',
-          password: 'password123',
-          email: 'existing@example.com',
-          authority: 'USER',
-        },
-      };
-      const res = createRes();
 
-      vi.spyOn(models.User, 'findOne').mockResolvedValue({
-        email: 'existing@example.com',
+    it('should return 400 if email already exists', async () => {
+      setupUserMocks({ 
+        findOneValue: { email: 'existing@example.com' } 
       });
+      
+      const req = createSignUpReq({ 
+        username: 'newUser', 
+        email: 'existing@example.com' 
+      });
+      const res = createRes();
 
       await userController.signUp(req, res);
 
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Email already exists',
-      });
+      expect(res.json).toHaveBeenCalledWith({ message: 'Email already exists' });
     });
 
     it('should hash password before saving user', async () => {
-      const req = {
-        body: {
-          username: 'newUser',
-          password: 'plainPassword',
-          email: 'test@example.com',
-          authority: 'USER',
-        },
-      };
+      setupUserMocks();
+      const hashSpy = vi.spyOn(bcrypt, 'hash').mockResolvedValue('hashedPassword');
+      
+      const req = createSignUpReq({ 
+        username: 'newUser', 
+        password: 'plainPassword' 
+      });
       const res = createRes();
-
-      vi.spyOn(models.User, 'findOne').mockResolvedValue(null);
-      vi.spyOn(models.User, 'findAll').mockResolvedValue([]);
-      const hashSpy = vi
-        .spyOn(bcrypt, 'hash')
-        .mockResolvedValue('hashedPassword');
-      vi.spyOn(models.User, 'create').mockResolvedValue({});
 
       await userController.signUp(req, res);
 
       expect(hashSpy).toHaveBeenCalledWith('plainPassword', 10);
       expect(models.User.create).toHaveBeenCalledWith({
         username: 'newUser',
-        password: 'hashedPassword', // should match the mocked hash
+        password: 'hashedPassword',
         authority: 'USER',
         email: 'test@example.com',
       });
     });
-    it('should return 500 if there is a server error during user creation', async () => {
-      const req = {
-        body: {
-          username: 'errorUser',
-          password: 'password123',
-          email: 'test@example.com',
-          authority: 'USER',
-        },
-      };
-      const res = createRes();
 
-      vi.spyOn(models.User, 'findOne').mockResolvedValue(null);
-      vi.spyOn(models.User, 'findAll').mockResolvedValue([]);
+    it('should return 500 if there is a server error during user creation', async () => {
+      setupUserMocks();
       vi.spyOn(models.User, 'create').mockRejectedValue(new Error('DB error'));
+      
+      const req = createSignUpReq({ username: 'errorUser' });
+      const res = createRes();
 
       await userController.signUp(req, res);
 
       expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Failed to create user, error',
-      });
+      expect(res.json).toHaveBeenCalledWith({ message: 'Failed to create user, error' });
     });
-    it('should create user with default authority USER if not provided', async () => {
-      // authority not provided
-      const req = {
-        body: {
-          username: 'defaultUser',
-          password: 'password123',
-          email: 'default@example.com',
-        },
-      };
-      const res = createRes();
 
-      vi.spyOn(models.User, 'findOne').mockResolvedValue(null);
-      vi.spyOn(models.User, 'findAll').mockResolvedValue([]);
+    it('should create user with default authority USER if not provided', async () => {
+      setupUserMocks();
       vi.spyOn(bcrypt, 'hash').mockResolvedValue('hashedPassword');
-      const createUserSpy = vi
-        .spyOn(models.User, 'create')
-        .mockResolvedValue({});
+      
+      const req = createSignUpReq({ 
+        username: 'defaultUser', 
+        email: 'default@example.com',
+        authority: undefined
+      });
+      const res = createRes();
 
       await userController.signUp(req, res);
 
@@ -224,10 +218,10 @@ describe('User Controller Tests', () => {
       expect(res.json).toHaveBeenCalledWith({
         message: 'User defaultUser created successfully with authority USER',
       });
-      expect(createUserSpy).toHaveBeenCalledWith({
+      expect(models.User.create).toHaveBeenCalledWith({
         username: 'defaultUser',
         password: 'hashedPassword',
-        authority: 'USER', // default authority
+        authority: 'USER',
         email: 'default@example.com',
       });
     });
@@ -235,17 +229,23 @@ describe('User Controller Tests', () => {
 
   // Test singIn
   describe('signIn', () => {
-    it('should return 404 if user not found in signIn', async () => {
-      const req = {
-        body: {
-          username: 'nonExistentUser',
-          password: 'password123',
-        },
-      };
-      const res = createRes();
+    function createSignInReq(username = 'existingUser', password = 'correctPassword') {
+      return { body: { username, password } };
+    }
 
-      // simulate no user found
-      vi.spyOn(models.User, 'findOne').mockResolvedValue(null);
+    function mockSuccessfulAuth(user = DEFAULT_USER) {
+      setupUserMocks({ 
+        findOneValue: user, 
+        compareValue: true 
+      });
+      vi.spyOn(jwt, 'sign').mockReturnValue(MOCK_TOKEN);
+    }
+
+    it('should return 404 if user not found in signIn', async () => {
+      setupUserMocks();
+      
+      const req = createSignInReq('nonExistentUser');
+      const res = createRes();
 
       await userController.signIn(req, res);
 
@@ -254,60 +254,34 @@ describe('User Controller Tests', () => {
     });
 
     it('should return 401 if password is invalid in signIn', async () => {
-      const req = {
-        body: {
-          username: 'existingUser',
-          password: 'wrongPassword',
-        },
-      };
+      setupUserMocks({ 
+        findOneValue: DEFAULT_USER 
+      });
+      
+      const req = createSignInReq('existingUser', 'wrongPassword');
       const res = createRes();
-      const mockUser = { username: 'existingUser', password: 'hashedPassword' };
-
-      vi.spyOn(models.User, 'findOne').mockResolvedValue(mockUser);
-
-      vi.spyOn(bcrypt, 'compare').mockResolvedValue(false);
 
       await userController.signIn(req, res);
 
-      expect(bcrypt.compare).toHaveBeenCalledWith(
-        'wrongPassword',
-        'hashedPassword'
-      );
+      expect(bcrypt.compare).toHaveBeenCalledWith('wrongPassword', 'hashedPassword');
       expect(res.status).toHaveBeenCalledWith(401);
       expect(res.json).toHaveBeenCalledWith({ message: 'Invalid password' });
     });
 
     it('should return 200 and a token if signIn is successful', async () => {
-      const req = {
-        body: {
-          username: 'existingUser',
-          password: 'correctPassword',
-        },
-      };
+      mockSuccessfulAuth();
+      
+      const req = createSignInReq();
       const res = createRes();
-      const mockUser = {
-        username: 'existingUser',
-        password: 'hashedPassword',
-        email: 'user@example.com',
-        authority: 'USER',
-      };
-
-      vi.spyOn(models.User, 'findOne').mockResolvedValue(mockUser);
-      vi.spyOn(bcrypt, 'compare').mockResolvedValue(true);
-      vi.spyOn(jwt, 'sign').mockReturnValue('mockToken');
-      vi.spyOn(models.User, 'update').mockResolvedValue([1]);
 
       await userController.signIn(req, res);
 
-      expect(bcrypt.compare).toHaveBeenCalledWith(
-        'correctPassword',
-        'hashedPassword'
-      );
+      expect(bcrypt.compare).toHaveBeenCalledWith('correctPassword', 'hashedPassword');
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          accessToken: 'mockToken',
-          refreshToken: 'mockToken',
+          accessToken: MOCK_TOKEN,
+          refreshToken: MOCK_TOKEN,
           username: 'existingUser',
           email: 'user@example.com',
           authority: 'USER',
@@ -315,64 +289,47 @@ describe('User Controller Tests', () => {
       );
 
       expect(models.User.update).toHaveBeenCalledWith(
-        { refresh_token: 'mockToken' },
+        { refresh_token: MOCK_TOKEN },
         { where: { username: 'existingUser' } }
       );
     });
 
-    it('should return 400 if username is missing', async () => {
-      const req = { body: { password: 'somePassword' } };
-      const res = createRes();
-
-      await userController.signIn(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Username and password are required',
-      });
-    });
-
-    it('should return 400 if password is missing', async () => {
-      const req = { body: { username: 'existingUser' } };
-      const res = createRes();
-
-      await userController.signIn(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Username and password are required',
-      });
+    it('should return 400 if username or password is missing', async () => {
+      const testCases = [
+        { body: { password: 'someLongAndStrongPassword.123.' } },
+        { body: { username: 'existingUser' } }
+      ];
+      
+      for (const req of testCases) {
+        const res = createRes();
+        await userController.signIn(req, res);
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({
+          message: 'Username and password are required',
+        });
+      }
     });
 
     it('should handle special characters in username', async () => {
-      const req = {
-        body: { username: 'user!@#', password: 'correctPassword' },
-      };
-      const res = createRes();
-
-      // Mock de usuario
-      const mockUser = {
+      const specialUser = {
         username: 'user!@#',
         password: 'hashedPassword',
         email: 'user@example.com',
         authority: 'userAuthority',
       };
-
-      vi.spyOn(models.User, 'findOne').mockResolvedValue(mockUser);
-      vi.spyOn(bcrypt, 'compare').mockResolvedValue(true);
-      vi.spyOn(jwt, 'sign').mockImplementation(() => 'mockToken');
+      
+      mockSuccessfulAuth(specialUser);
+      
+      const req = createSignInReq('user!@#');
+      const res = createRes();
 
       await userController.signIn(req, res);
 
-      expect(bcrypt.compare).toHaveBeenCalledWith(
-        'correctPassword',
-        'hashedPassword'
-      );
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          accessToken: 'mockToken',
-          refreshToken: 'mockToken',
+          accessToken: MOCK_TOKEN,
+          refreshToken: MOCK_TOKEN,
           username: 'user!@#',
           email: 'user@example.com',
           authority: 'userAuthority',
@@ -380,122 +337,82 @@ describe('User Controller Tests', () => {
         })
       );
     });
-    it('should be case insensitive for username in signIn', async () => {
-      const req = {
-        body: { username: 'ExistingUser', password: 'correctPassword' },
-      };
-      const res = createRes();
 
-      const mockUser = {
-        username: 'existinguser', // lowercase,
+    it('should be case insensitive for username in signIn', async () => {
+      const lowerCaseUser = {
+        username: 'existinguser',
         password: 'hashedPassword',
         email: 'user@example.com',
         authority: 'userAuthority',
       };
-
-      vi.spyOn(models.User, 'findOne').mockResolvedValue(mockUser);
-      vi.spyOn(bcrypt, 'compare').mockResolvedValue(true);
-      vi.spyOn(jwt, 'sign').mockReturnValue('mockToken');
+      
+      mockSuccessfulAuth(lowerCaseUser);
+      
+      const req = createSignInReq('ExistingUser');
+      const res = createRes();
 
       await userController.signIn(req, res);
 
-      expect(bcrypt.compare).toHaveBeenCalledWith(
-        'correctPassword',
-        'hashedPassword'
-      );
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          accessToken: 'mockToken',
-          refreshToken: 'mockToken',
-          username: mockUser.username,
-          email: mockUser.email,
-          authority: mockUser.authority,
+          accessToken: MOCK_TOKEN,
+          refreshToken: MOCK_TOKEN,
+          username: lowerCaseUser.username,
+          email: lowerCaseUser.email,
+          authority: lowerCaseUser.authority,
           nodeRedToken: '',
         })
       );
     });
+
     it('should generate valid accessToken and refreshToken', async () => {
-      const req = {
-        body: { username: 'existingUser', password: 'correctPassword' },
-      };
+      mockSuccessfulAuth();
+      
+      const req = createSignInReq();
       const res = createRes();
-
-      const mockUser = { username: 'existingUser', password: 'hashedPassword' };
-
-      vi.spyOn(models.User, 'findOne').mockResolvedValue(mockUser);
-      vi.spyOn(bcrypt, 'compare').mockResolvedValue(true);
-      const signSpy = vi.spyOn(jwt, 'sign').mockReturnValue('mockToken');
 
       await userController.signIn(req, res);
 
-      expect(signSpy).toHaveBeenCalledTimes(2); // accessToken y refreshToken
+      expect(jwt.sign).toHaveBeenCalledTimes(2);
     });
 
     it('should handle database error during user lookup in signIn', async () => {
-      const req = {
-        body: {
-          username: 'existingUser',
-          password: 'password123',
-        },
-      };
+      vi.spyOn(models.User, 'findOne').mockRejectedValue(new Error('Database error'));
+      
+      const req = createSignInReq();
       const res = createRes();
-
-      // Mocking the database error
-      vi.spyOn(models.User, 'findOne').mockRejectedValue(
-        new Error('Database error')
-      );
 
       await userController.signIn(req, res);
 
       expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Internal server error',
-      });
-      console.error('Error in signIn:', new Error('Database error')); 
+      expect(res.json).toHaveBeenCalledWith({ message: 'Internal server error' });
     });
-    it('should call getNodeRedToken and include it in the response and cookie for DEVELOPER', async () => {
-      const req = {
-        body: {
-          username: 'developerUser',
-          password: 'developerPassword',
-        },
-      };
-      const res = createRes();
-      const mockDeveloperUser = {
+
+    it('should call getNodeRedToken and include it in the response for DEVELOPER', async () => {
+      const developerUser = {
         id: 123,
         username: 'developerUser',
         password: 'hashedDeveloperPassword',
         email: 'developer@example.com',
         authority: 'DEVELOPER',
       };
+      
+      mockSuccessfulAuth(developerUser);
+      const getNodeRedTokenSpy = vi.spyOn(nodeRedTokenModule, 'getNodeRedToken')
+        .mockResolvedValue({ accessToken: 'mockNodeRedToken' });
+      
+      const req = createSignInReq('developerUser', 'developerPassword');
+      const res = createRes();
 
-      vi.spyOn(models.User, 'findOne').mockResolvedValue(mockDeveloperUser);
-      vi.spyOn(bcrypt, 'compare').mockResolvedValue(true);
-      vi.spyOn(jwt, 'sign').mockReturnValue('mockToken');
-      vi.spyOn(models.User, 'update').mockResolvedValue([1]);
-      const getNodeRedTokenSpy = vi
-        .spyOn(nodeRedTokenModule, 'getNodeRedToken')
-        .mockResolvedValue({
-          accessToken: 'mockNodeRedToken',
-        });
       await userController.signIn(req, res);
-      //getNodeRedTokenSpy.mockRestore();
-      expect(getNodeRedTokenSpy).toHaveBeenCalledWith(
-        'developerUser',
-        'developerPassword'
-      );
+
+      expect(getNodeRedTokenSpy).toHaveBeenCalledWith('developerUser', 'developerPassword');
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          accessToken: 'mockToken',
-          refreshToken: 'mockToken',
-          username: 'developerUser',
-          email: 'developer@example.com',
           authority: 'DEVELOPER',
-          nodeRedToken: {
-            accessToken: 'mockNodeRedToken',
-          },
+          nodeRedToken: { accessToken: 'mockNodeRedToken' },
         })
       );
     });
@@ -504,54 +421,40 @@ describe('User Controller Tests', () => {
   // Test signOut
   describe('signOut', () => {
     it('should return 400 if no refreshToken in signOut', async () => {
-      const req = {
-        refreshToken: null,
-      };
+      const req = { cookies: {} };
       const res = createRes();
 
       await userController.signOut(req, res);
 
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'No refresh token provided',
-      });
+      expect(res.json).toHaveBeenCalledWith({ message: 'No refresh token provided' });
     });
 
-    it('should return 204 sign out successfully', async () => {
+    it('should return 204 and clear all cookies when sign out successfully', async () => {
+      const token = 'validToken';
+      const mockUser = [{ id: 1, username: 'existingUser', refresh_token: token }];
+      setupUserMocks({ findAllValue: mockUser });
+      
+      const req = { cookies: { refreshToken: token } };
       const res = createRes();
-      // FIX: Token must be in req.cookies
-      const req = {
-        cookies: { refreshToken: 'validToken' },
-      };
-      const user = [
-        { id: 1, username: 'existingUser', refresh_token: 'validToken' },
-      ];
-
-      vi.spyOn(models.User, 'findAll').mockResolvedValue(user);
-      vi.spyOn(models.User, 'update').mockResolvedValue([1]);
 
       await userController.signOut(req, res);
 
-      expect(res.status).toHaveBeenCalledWith(204);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Signed out successfully',
-      });
-      // FIX: Verify that the cookie is cleared
-      expect(res.clearCookie).toHaveBeenCalledWith(
-        'refreshToken',
-        expect.any(Object)
+      expect(models.User.findAll).toHaveBeenCalledWith({ where: { refresh_token: token } });
+      expect(models.User.update).toHaveBeenCalledWith(
+        { refresh_token: '' },
+        { where: { refresh_token: token } }
       );
+      expectCookiesCleared(res);
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Signed out successfully' });
     });
 
-    it('should return 404 if user not found for refreshToken', async () => {
-      // Mock invalid token
-      const req = {
-        cookies: { refreshToken: 'invalidToken' },
-      };
+    it('should return 404 and clear all cookies if user not found for refreshToken', async () => {
+      setupUserMocks({ findAllValue: [] });
+      
+      const req = { cookies: { refreshToken: 'invalidToken' } };
       const res = createRes();
-
-      // Mocking the user not found scenario
-      vi.spyOn(models.User, 'findAll').mockResolvedValue([]); // No user with that refresh token
 
       await userController.signOut(req, res);
 
@@ -559,47 +462,14 @@ describe('User Controller Tests', () => {
       expect(res.json).toHaveBeenCalledWith({
         message: 'No user found for provided refresh token',
       });
-      expect(res.clearCookie).toHaveBeenCalledWith(
-        'refreshToken',
-        expect.any(Object)
-      );
+      expectCookiesCleared(res);
     });
-    it('should return 204 sign out successfully', async () => {
-      const res = createRes();
-      const req = { cookies: { refreshToken: 'validToken' } };
-      const mockUser = [
-        { id: 1, username: 'existingUser', refresh_token: 'validToken' },
-      ];
 
-      vi.spyOn(models.User, 'findAll').mockResolvedValue(mockUser);
-      vi.spyOn(models.User, 'update').mockResolvedValue([1]);
-
-      await userController.signOut(req, res);
-
-      expect(models.User.findAll).toHaveBeenCalledWith({
-        where: { refresh_token: 'validToken' },
-      });
-      expect(models.User.update).toHaveBeenCalledWith(
-        { refresh_token: '' },
-        { where: { refresh_token: 'validToken' } }
-      );
-      expect(res.clearCookie).toHaveBeenCalledWith('refreshToken', {
-        httpOnly: true,
-        secure: true,
-        sameSite: 'none',
-      });
-      expect(res.status).toHaveBeenCalledWith(204);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Signed out successfully',
-      });
-    });
     it('should handle database error during user lookup in signOut', async () => {
+      vi.spyOn(models.User, 'findAll').mockRejectedValue(new Error('Database error'));
+      
       const req = { cookies: { refreshToken: 'someToken' } };
       const res = createRes();
-
-      vi.spyOn(models.User, 'findAll').mockRejectedValue(
-        new Error('Database error')
-      );
 
       await userController.signOut(req, res);
 
@@ -621,10 +491,10 @@ describe('User Controller Tests', () => {
   // Test para deleteUserById
   describe('deleteUserById', () => {
     it('should return 404 if user not found in deleteUserById', async () => {
-      const res = createRes();
-      const req = { params: { id: 1 } };
-
       vi.spyOn(models.User, 'findByPk').mockResolvedValue(null);
+      
+      const req = { params: { id: 1 } };
+      const res = createRes();
 
       await userController.deleteUserById(req, res);
 
@@ -633,44 +503,38 @@ describe('User Controller Tests', () => {
     });
 
     it('should delete user successfully in deleteUserById', async () => {
-      const res = createRes();
-      const user = {
+      const mockUser = {
         id: 1,
         username: 'existingUser',
-        destroy: vi.fn().mockResolvedValue({}), // destroy() is a real function that returns a resolved promise.
+        destroy: vi.fn().mockResolvedValue({}),
       };
-
-      vi.spyOn(models.User, 'findByPk').mockResolvedValue(user);
-      vi.spyOn(models.User, 'destroy').mockResolvedValue({});
-
+      vi.spyOn(models.User, 'findByPk').mockResolvedValue(mockUser);
+      
       const req = { params: { id: 1 } };
+      const res = createRes();
 
       await userController.deleteUserById(req, res);
 
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'User deleted successfully',
-      });
+      expect(res.json).toHaveBeenCalledWith({ message: 'User deleted successfully' });
     });
+
     it('should handle database error during user deletion in deleteUserById', async () => {
-      const res = createRes();
-      const req = { params: { id: 1 } };
       const mockUser = {
         id: 1,
         username: 'existingUser',
-        destroy: vi.fn().mockRejectedValue(new Error('Database error')), // Simulate an error during destroy
+        destroy: vi.fn().mockRejectedValue(new Error('Database error')),
       };
-
       vi.spyOn(models.User, 'findByPk').mockResolvedValue(mockUser);
+      
+      const req = { params: { id: 1 } };
+      const res = createRes();
 
       await userController.deleteUserById(req, res);
 
-      expect(models.User.findByPk).toHaveBeenCalledWith(1);
       expect(mockUser.destroy).toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Internal server error',
-      });
+      expect(res.json).toHaveBeenCalledWith({ message: 'Internal server error' });
       expect(console.error).toHaveBeenCalledWith(
         'Error in deleteUserById:',
         new Error('Database error')
@@ -680,19 +544,24 @@ describe('User Controller Tests', () => {
 
   // Test getAuthority
   describe('getAuthority', () => {
-    it('should return authority if valid token is provided', async () => {
-      const mockAuthority = 'admin';
-      const mockToken = 'validToken';
-
-      const req = { cookies: { accessToken: mockToken } };
+    function setupTokenTest(token, authority = null) {
+      const req = { cookies: { accessToken: token } };
       const res = createRes();
+      
+      if (authority) {
+        vi.spyOn(jwt, 'verify').mockReturnValue({ authority });
+      }
+      
+      return { req, res };
+    }
 
-      vi.spyOn(jwt, 'verify').mockReturnValue({ authority: mockAuthority });
+    it('should return authority if valid token is provided', async () => {
+      const { req, res } = setupTokenTest('validToken', 'admin');
 
       await userController.getAuthority(req, res);
 
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith({ authority: mockAuthority });
+      expect(res.json).toHaveBeenCalledWith({ authority: 'admin' });
     });
 
     it('should return 400 if no token is provided', async () => {
@@ -704,12 +573,9 @@ describe('User Controller Tests', () => {
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({ message: 'Token is required' });
     });
+
     it('should return 403 if the token is invalid or expired', async () => {
-      const mockToken = 'invalidToken';
-
-      const req = { cookies: { accessToken: mockToken } };
-      const res = createRes();
-
+      const { req, res } = setupTokenTest('invalidToken');
       vi.spyOn(jwt, 'verify').mockImplementation(() => {
         throw new Error('Invalid token');
       });
@@ -719,12 +585,9 @@ describe('User Controller Tests', () => {
       expect(res.status).toHaveBeenCalledWith(403);
       expect(res.json).toHaveBeenCalledWith({ message: 'Invalid token' });
     });
+
     it('should return 403 if the token format is incorrect', async () => {
-      const mockToken = 'malformedToken';
-
-      const req = { cookies: { accessToken: mockToken } };
-      const res = createRes();
-
+      const { req, res } = setupTokenTest('malformedToken');
       vi.spyOn(jwt, 'verify').mockImplementation(() => {
         throw new Error('jwt malformed');
       });
@@ -736,18 +599,12 @@ describe('User Controller Tests', () => {
     });
 
     it('should return 200 if token has authority ADMIN', async () => {
-      const mockAuthority = 'ADMIN';
-      const mockToken = 'validTokenWithAdminAuthority';
-
-      const req = { cookies: { accessToken: mockToken } };
-      const res = createRes();
-
-      vi.spyOn(jwt, 'verify').mockReturnValue({ authority: mockAuthority });
+      const { req, res } = setupTokenTest('validTokenWithAdminAuthority', 'ADMIN');
 
       await userController.getAuthority(req, res);
 
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith({ authority: mockAuthority });
+      expect(res.json).toHaveBeenCalledWith({ authority: 'ADMIN' });
     });
   });
 });


### PR DESCRIPTION
This pull request enhances the `signOut` functionality in the `user.controller.js` file to clear all relevant cookies (`refreshToken`, `accessToken`, `nodeRedToken`) and updates the associated documentation and unit tests to reflect these changes. The most important changes are grouped below:

### Updates to `signOut` Functionality

* Modified the `signOut` method in `src/controllers/user.controller.js` to clear additional cookies (`accessToken` and `nodeRedToken`) alongside `refreshToken` during the logout process. This ensures a more secure and comprehensive sign-out. [[1]](diffhunk://#diff-c373c041b58a1e53371b4322a252ce01e00939936e27ba5ea486a632533d2ffeR155-R164) [[2]](diffhunk://#diff-c373c041b58a1e53371b4322a252ce01e00939936e27ba5ea486a632533d2ffeR182-R191)

### Documentation Updates

* Updated the Swagger documentation in `src/routes/user.routes.js` to reflect that all cookies (`accessToken`, `refreshToken`, `nodeRedToken`) are cleared during sign-out. Added descriptions for new response scenarios (`404` for no user found, `400` for no refresh token provided).

### Unit Test Enhancements

* Improved unit tests in `tests/unit/controllers/user/user.controller.test.js` to validate that all cookies are cleared (`refreshToken`, `accessToken`, `nodeRedToken`) during successful sign-out and when no user is found for the provided refresh token.
* Fixed test case to correctly handle scenarios where no `refreshToken` is provided in the request by updating the mock request structure.