### PR TITLE
test: added index routes test

### DIFF
--- a/tests/integration/routes/index.routes.test.js
+++ b/tests/integration/routes/index.routes.test.js
@@ -1,22 +1,9 @@
 import { expect, describe, it, beforeAll } from 'vitest';
 import { request } from '../../setup/setup.js';
-import jwt from 'jsonwebtoken';
-import { adminUser } from '../../utils/sampleUserData.js';
 
-describe('Scope API Routes', () => {
-  let token;
+describe('API Main Route', () => {
 
   beforeAll(async () => {
-    token = jwt.sign(
-      {
-        userId: adminUser._id,
-        username: adminUser.username,
-        authority: adminUser.authority,
-      },
-      'test-secret-key'
-    );
-
-    request.set('Cookie', `accessToken=${token}`);
   });
 
   describe('Index GET /', () => {

--- a/tests/integration/routes/index.routes.test.js
+++ b/tests/integration/routes/index.routes.test.js
@@ -1,0 +1,31 @@
+import { expect, describe, it, beforeAll } from 'vitest';
+import { request } from '../../setup/setup.js';
+import jwt from 'jsonwebtoken';
+import { adminUser } from '../../utils/sampleUserData.js';
+
+describe('Scope API Routes', () => {
+  let token;
+
+  beforeAll(async () => {
+    token = jwt.sign(
+      {
+        userId: adminUser._id,
+        username: adminUser.username,
+        authority: adminUser.authority,
+      },
+      'test-secret-key'
+    );
+
+    request.set('Cookie', `accessToken=${token}`);
+  });
+
+  describe('Index GET /', () => {
+    it('should return a 200 status code and the welcome message', async () => {
+      const response = await request.get('/');
+
+      expect(response.status).toBe(200);
+      expect(response.text).toBe('Welcome to the API!');
+      expect(response.type).toBe('text/html');
+    });
+  });
+});


### PR DESCRIPTION
feat: Add basic index route test

This commit introduces a test case for the root GET '/' endpoint.

The test verifies that:
- The endpoint returns a 200 OK status code.
- The response body contains the "Welcome to the API!" message.
- The Content-Type header is set to "text/html".

Authentication is set up in the `beforeAll` block by generating a JWT and setting it as a cookie in the request, although the current index route does not require authentication. This provides a foundation for testing protected routes in the future.