### PR TITLE
test: add panel utils unit tests

### DIFF
--- a/tests/unit/utils/panelUtils.test.js
+++ b/tests/unit/utils/panelUtils.test.js
@@ -1,41 +1,144 @@
-import { describe, it, expect } from 'vitest';
-import { mapPanelsToDTO } from '../../../src/utils/panelUtils.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as grafanaService from '../../../src/config/grafana.js';
+import redis from '../../../src/config/redis.js';
+import * as panelUtils from '../../../src/utils/panelUtils.js';
 
-describe('panelUtils - mapPanelsToDTO', () => {
-  it('should return an empty array when no panels are provided', async () => {
-    const result = await mapPanelsToDTO([]);
-    expect(result).toEqual([]);
+
+describe('mapPanelsToDTO', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    vi.spyOn(redis, 'get');
+    vi.spyOn(redis, 'set');
+    vi.spyOn(grafanaService.methods.dashboard, 'getDashboardByUID');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('should skip panels without dashboardUid', async () => {
-    const panels = [
-      { id: 1, title: 'Panel 1' },
-      { id: 2, title: 'Panel 2' }
-    ];
-
-    const result = await mapPanelsToDTO(panels);
+    const panels = [{ id: 1 }, { id: 2, dashboardUid: null }, { id: 3, dashboardUid: '' }];
+    const result = await panelUtils.mapPanelsToDTO(panels);
     expect(result).toEqual([]);
   });
 
-  it('should handle errors when fetching from Grafana API gracefully', async () => {
-    const panels = [
-      { id: 1, dashboardUid: 'invalid-uid-that-does-not-exist' }
-    ];
+  it('should return cached panel data if present in Redis', async () => {
+    const panels = [{ id: 1, dashboardUid: 'uid1', name: 'panel1' }];
 
-    // This should not throw an error, but return empty array
-    const result = await mapPanelsToDTO(panels);
-    expect(Array.isArray(result)).toBe(true);
+    redis.get.mockResolvedValueOnce(JSON.stringify({ title: 'Cached Title', type: 'graph' }));
+
+    const result = await panelUtils.mapPanelsToDTO(panels);
+
+    expect(redis.get).toHaveBeenCalledWith('grafana:panel:1');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 1,
+      dashboardUid: 'uid1',
+      title: 'Cached Title',
+      type: 'graph',
+      name: 'panel1',
+    });
+    expect(redis.set).not.toHaveBeenCalled();
   });
 
-  it('should handle panels with dataValues property', async () => {
-    const panels = [
-      {
-        dataValues: { id: 2, title: 'Test' }
-      }
-    ];
+  it('should fetch from Grafana and cache when Redis cache misses', async () => {
+    const panels = [{ id: 42, dashboardUid: 'dash123', foo: 'bar' }];
 
-    // Should skip panels without dashboardUid even with dataValues
-    const result = await mapPanelsToDTO(panels);
+    redis.get.mockResolvedValueOnce(null);
+
+    const dashboardResponse = {
+      data: {
+        dashboard: {
+          panels: [
+            {
+              id: 42,
+              title: 'Panel Title',
+              type: 'table',
+              gridPos: { h: 5, w: 10, x: 0, y: 0 },
+              targets: [
+                { rawSql: 'SELECT * FROM table', table: 'table', alias: 'Display Name' }
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    grafanaService.methods.dashboard.getDashboardByUID.mockResolvedValue(dashboardResponse);
+    redis.set.mockResolvedValue('OK');
+
+    const result = await panelUtils.mapPanelsToDTO(panels);
+
+    expect(redis.get).toHaveBeenCalledWith('grafana:panel:42');
+    expect(grafanaService.methods.dashboard.getDashboardByUID).toHaveBeenCalledWith('dash123');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: 42,
+      dashboardUid: 'dash123',
+      title: 'Panel Title',
+      type: 'table',
+      sqlQuery: 'SELECT * FROM table',
+      table: 'table',
+      displayName: 'Display Name',
+      gridPos: { h: 5, w: 10, x: 0, y: 0 },
+      foo: 'bar',
+    });
+
+    expect(redis.set).toHaveBeenCalledWith(
+      'grafana:panel:42',
+      JSON.stringify({
+        title: 'Panel Title',
+        type: 'table',
+        sqlQuery: 'SELECT * FROM table',
+        table: 'table',
+        displayName: 'Display Name',
+        gridPos: { h: 5, w: 10, x: 0, y: 0 },
+      }),
+      'EX',
+      7 * 24 * 60 * 60
+    );
+  });
+
+  it('should skip panel if not found in fetched dashboard panels', async () => {
+    const panels = [{ id: 100, dashboardUid: 'dashX' }];
+
+    redis.get.mockResolvedValueOnce(null);
+
+    const dashboardResponse = {
+      data: {
+        dashboard: {
+          panels: [
+            { id: 101, title: 'Other Panel', type: 'graph' }
+          ],
+        },
+      },
+    };
+
+    grafanaService.methods.dashboard.getDashboardByUID.mockResolvedValue(dashboardResponse);
+
+    const result = await panelUtils.mapPanelsToDTO(panels);
+
     expect(result).toEqual([]);
+  });
+
+  it('should catch errors and skip panel on Grafana API failure', async () => {
+    const panels = [{ id: 5, dashboardUid: 'badUID' }];
+
+    redis.get.mockResolvedValueOnce(null);
+    grafanaService.methods.dashboard.getDashboardByUID.mockRejectedValue(new Error('API error'));
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await panelUtils.mapPanelsToDTO(panels);
+
+    expect(result).toEqual([]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Error mapping panel 5 for dashboard badUID:',
+      expect.any(Error)
+    );
+
+    consoleErrorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
test(panelUtils): add comprehensive unit tests for mapPanelsToDTO with Redis and Grafana integration

- Verify skipping panels without dashboardUid
- Ensure cached panel data is returned from Redis without API calls
- Test fetching panel data from Grafana when Redis cache misses
- Validate correct Redis caching of fetched panel metadata
- Handle panels not found in the dashboard's panel list
- Ensure errors from Grafana API are caught and logged without breaking flow
